### PR TITLE
Added missing space in classes string.

### DIFF
--- a/class.dumper.php
+++ b/class.dumper.php
@@ -1227,7 +1227,7 @@ class Dumper {
 
         // Setup the CSS classes depending on how many children there are
         if ($childCount > 0 && $collapsed ) {
-            $elementClasses = 'dumper-expand';
+            $elementClasses = ' dumper-expand';
         } elseif ($childCount > 0 && $traverse_this ) {
             $elementClasses = ' dumper-expand dumper-opened';
         } else {


### PR DESCRIPTION
Missing space caused class errors:

<div class="dumper-elementdumper-expand   ...

Should have been:

<div class="dumper-element dumper-expand  ...
