### PR TITLE
Remove hard dependency on Bolt's lib method.

### DIFF
--- a/class.dumper.php
+++ b/class.dumper.php
@@ -1480,7 +1480,13 @@ class Dumper {
      */
     private static function trimString($str, $length = 40)
     {
-        if (getStringLength($str) > $length) {
+        if (function_exists('mb_strwidth')) {
+            $strlen =  mb_strwidth($str, 'UTF-8');
+        } else {
+            $strlen =  strlen($str);
+        }
+
+        if ($strlen > $length) {
             $str = mb_substr($str, 0, $length, "UTF-8");
             $str .= '…';
         }


### PR DESCRIPTION
trimString had an old reference to getStringLength, which has since moved to Bolt\Library, and is otherwise unused in Bolt.  Copied the functionality inline here as this doesn't have (and probably shouldn't have) a composer requirement of Bolt. (Circular dependencies, wheeee!)

Cheers!
